### PR TITLE
Updated Travis.ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: true
 language: ruby
 addons:
@@ -9,5 +9,7 @@ addons:
 script:
   - make ci
 rvm:
+  - 2.6
+  - 2.5
   - 2.4
   - 2.3


### PR DESCRIPTION
This PR adds Ruby versions 2.5 and 2.6 to the travis.ci file to ensure future compatibility with Gems.

The Ubuntu image used by travis has also been updated as trusty is EOL as of April.