### PR TITLE
feat(#35): add new config make target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add new make target `config` to replace deprecated make targets `config-aem-aws` & `config-aem`#35
+
+### Changed
+- Make targets `config-aem-aws` & `config-aem` are now deprecated #35
+
 ## 1.9.0 - 2019-12-12
 ### Changed
 - Reset last gem updates in order to maintain consistency with sub-deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add new make target `config` to replace deprecated make targets `config-aem-aws` & `config-aem`#35
 
-### Changed
+### Removed
 - Make targets `config-aem-aws` & `config-aem` are now deprecated #35
 
 ## 1.9.0 - 2019-12-12

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,15 @@ deps:
 lint:
 	bundle exec rubocop Gemfile
 
+# Deprecated
+config-aem-aws: config
+# Deprecated
+config-aem: config
+
 # copy user config to InSpec profiles config
-config-aem-aws:
-	cp $(config_path)/aem-aws.yaml vendor/inspec-aem-aws/conf/aem-aws.yaml
-config-aem:
-	cp $(config_path)/aem.yaml vendor/inspec-aem-security/conf/aem.yaml
+config:
+	yes|cp $(config_path)/* vendor/inspec-aem-aws/conf/
+	yes|cp $(config_path)/* vendor/inspec-aem-security/conf/
 
 acceptance:
 	rspec acceptance/


### PR DESCRIPTION
- Added new make target `config` to overwrite all configuration from an 
InSpec profile #35

- Make targets `config-aem-aws` & `config-aem` are now deprecated #35